### PR TITLE
[BUGFIX] Abby Modifiers Short-Circuiting

### DIFF
--- a/plover_lapwing/dictionaries/abby-left-hand-modifiers.py
+++ b/plover_lapwing/dictionaries/abby-left-hand-modifiers.py
@@ -144,18 +144,18 @@ def lookup(outline):
 
     mods = modifiers.index(str1)  # get index of modifier keys
     # length should be 2
-    if len(outline) == 2:
-        str2 = outline[1]
-        # do nothing if second stroke is SKPH
-        if str2 == "SKPH":
-            return "{#}"
-        if str2 not in keys:
-            raise KeyError
-        assert str2 in keys
-        # get key to press from second stroke
-        key = keys.get(str2)
-    else:
-        key = ""
+    if len(outline) != 2:
+        raise KeyError
+
+    str2 = outline[1]
+    # do nothing if second stroke is SKPH
+    if str2 == "SKPH":
+        return "{#}"
+    if str2 not in keys:
+        raise KeyError
+    assert str2 in keys
+    # get key to press from second stroke
+    key = keys.get(str2)
 
     # add modifiers
     # 8 = super


### PR DESCRIPTION
# Description
This PR fixes an issue with Abby's modifier dictionary "short-circuiting" and providing translations on the first stroke instead of buffering them and waiting for the complete sequence. Modifier keys are irreversible by nature, so the typical "undo-replace"-type approach used by Plover to correct valid prefix sequences won't work here. 

This change solves the problem by not providing a translation for any sequences of strokes of length not equal to two.