### PR TITLE
Fix issue causing the plugin manager to freeze

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ keywords = plover plover_plugin
 [options]
 zip_safe = True
 python_requires = >=3.6
+setup_requires =
+	setuptools<77
 install_requires =
 	plover>=4.0.0.dev11
 	plover-dict-commands


### PR DESCRIPTION
This should fix the issue with the plugins manager freezing. The problem is that Plover v4 uses an older version of `pkginfo` which only supports `Metadata-Version <= 2.2`. This PR locks the version of `setuptools` so that the build uses a supported `Metadata-Version`.

It looks like Plover v5 will use a more recent version of `pkginfo` so this is only needed to support Plover v4.

See more: https://github.com/openstenoproject/plover/issues/1714