### PR TITLE
Fix outline for "Crusades"

### DIFF
--- a/plover_lapwing/dictionaries/lapwing-prefixed-proper-nouns.json
+++ b/plover_lapwing/dictionaries/lapwing-prefixed-proper-nouns.json
@@ -7222,7 +7222,7 @@
 "#/KRAEUPB": "Crane",
 "#/KRAEUG": "Craig",
 "#/KRAEUGS/HR*EUS": "Craigslist",
-"#/KRAU/SAEUDZ": "Crusades",
+"#/KRAOU/SAEUDZ": "Crusades",
 "#/KRAU/TPO*RD": "Crawford",
 "#/KRAU/TPORD": "Crawford",
 "#/KRAUS": "Kraus",

--- a/plover_lapwing/dictionaries/lapwing-proper-nouns.json
+++ b/plover_lapwing/dictionaries/lapwing-proper-nouns.json
@@ -7223,7 +7223,7 @@
 "#KRAEUPB": "Crane",
 "#KRAEUG": "Craig",
 "#KRAEUGS/HR*EUS": "Craigslist",
-"#KRAU/SAEUDZ": "Crusades",
+"#KRAOU/SAEUDZ": "Crusades",
 "#KRAU/TPO*RD": "Crawford",
 "#KRAU/TPORD": "Crawford",
 "#KRAUS": "Kraus",


### PR DESCRIPTION
`#KRAU/SAEUDZ` should be `#KRAOU/SAEUDZ`.